### PR TITLE
Upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -24,6 +24,6 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.5
+    rev: 2.1.1
     hooks:
       - id: prettier


### PR DESCRIPTION
The pre-commit hooks have been updated to their latest version. Most
importantly, Prettier has been updated to its latest release to be
aligned with the version pulled from NPM as a dev dependency.